### PR TITLE
Bump actions/checkout from 2.3.5 to 2.4.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
 
   steps:
 
-    - uses: actions/checkout@v2.3.5
+    - uses: actions/checkout@v2.4.0
       with:
         fetch-depth: '${{ inputs.checkout-fetch-depth }}'
 


### PR DESCRIPTION
https://github.com/actions/checkout/releases/tag/v2.4.0

