### PR TITLE
Bump actions/cache from 2.1.6 to 2.1.7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
         java-version: '${{ inputs.java-version }}'
         distribution: '${{ inputs.java-distribution }}'
 
-    - uses: actions/cache@v2.1.6
+    - uses: actions/cache@v2.1.7
       with:
         path: |
           ${{ inputs.cache-path }}


### PR DESCRIPTION
https://github.com/actions/cache/releases/tag/v2.1.7

