### PR TITLE
Update output command for Maven version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ runs:
         restore-keys: ${{ inputs.cache-prefix }}${{ runner.os }}-jdk${{ inputs.java-version }}-${{ inputs.java-distribution }}-maven${{ inputs.maven-version }}-
 
     - name: Installed Maven version
-      run:  echo "version=$(mvn -q -v)" >> $GITHUB_OUTPUT
+      run:  echo "version='$(mvn -q -v)'" >> $GITHUB_OUTPUT
       shell: bash
       id: current-maven
 


### PR DESCRIPTION
The command `echo "version=$(mvn -q -v)" >> $GITHUB_OUTPUT` lead to these errors:
```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'Maven home: /usr/share/maven'
```