### PR TITLE
#58 New feature to support repository and token options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ For default values you only need:
 
 ## checkout
 
-| params                       | destination         | default |
-|------------------------------|---------------------|---------|
-| checkout-fetch-depth         | fetch-depth         |         |
-| checkout-path                | path                |         |
-| checkout-ref                 | ref                 |         |
-| checkout-persist-credentials | persist-credentials | false   |
+| params                       | destination         | default                  |
+|------------------------------|---------------------|--------------------------|
+| checkout-fetch-depth         | fetch-depth         |                          |
+| checkout-path                | path                |                          |
+| checkout-ref                 | ref                 |                          |
+| checkout-repository          | repository          | ${{ github.repository }} |
+| checkout-token               | token               | ${{ github.token }}      |
+| checkout-persist-credentials | persist-credentials | false                    |
 
 ## setup-java
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: 'The branch, tag, or SHA of the repository to clone'
     required: false
 
+  checkout-repository:
+    description: 'The repository to checkout if not the repository that triggered the action. For use when building GitHub Apps'
+    required: false
+
+  checkout-token:
+    description: 'Token to use for checkout if checking out a repository out of scope for GITHUB_TOKEN'
+    required: false
+
   # java jdk params
 
   java-version:
@@ -85,6 +93,8 @@ runs:
         path: '${{ inputs.checkout-path }}'
         persist-credentials: '${{ inputs.checkout-persist-credentials }}'
         ref: '${{ inputs.checkout-ref }}'
+        repository: '${{ inputs.checkout-repository }}'
+        token: '${{ inputs.checkout-token }}'
 
     - uses: actions/setup-java@v3
       with:

--- a/action.yml
+++ b/action.yml
@@ -28,10 +28,12 @@ inputs:
   checkout-repository:
     description: 'The repository to checkout if not the repository that triggered the action. For use when building GitHub Apps'
     required: false
+    default: ${{ github.repository }}
 
   checkout-token:
     description: 'Token to use for checkout if checking out a repository out of scope for GITHUB_TOKEN'
     required: false
+    default: ${{ github.token }}
 
   # java jdk params
 


### PR DESCRIPTION
<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->

To add support for the repository and token options on actions/checkout. This enables checking out a different repository (not the current repository or the calling repository) by passing the organization/repository. Also needed to support this is a token that has access to that repository because GITHUB_TOKEN is only locally scoped to a calling repository or the current repository.

Introduces feature request documented in issue: https://github.com/s4u/setup-maven-action/issues/58. 