### PR TITLE
Format action's output 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,11 @@ runs:
         restore-keys: ${{ inputs.cache-prefix }}${{ runner.os }}-jdk${{ inputs.java-version }}-${{ inputs.java-distribution }}-maven${{ inputs.maven-version }}-
 
     - name: Installed Maven version
-      run:  echo "version=$(mvn -q -v)" >> $GITHUB_OUTPUT
+      run: |
+        version_info=$(mvn -q -v)
+        echo "version<<EOF" >> $GITHUB_OUTPUT
+        echo $version_info >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
       shell: bash
       id: current-maven
 


### PR DESCRIPTION
To fix following error message

<img width="617" alt="Screenshot 2024-01-05 at 9 25 10 PM" src="https://github.com/s4u/setup-maven-action/assets/28893058/f3a57b7f-69af-4a89-bfb6-bef4d19d8d6d">

w.r.t github's announcement
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
