### PR TITLE
Update stCarolas/setup-maven to v5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
       shell: bash
       id: current-maven
 
-    - uses: stCarolas/setup-maven@v4.5
+    - uses: stCarolas/setup-maven@v5
       if: inputs.maven-version != steps.current-maven.outputs.version
       with:
         maven-version: '${{ inputs.maven-version }}'


### PR DESCRIPTION
The change proposed updates `stCarolas/setup-maven` to v5 working towards https://github.com/s4u/setup-maven-action/issues/71

v5 contains the update required to Node.js 20: https://github.com/stCarolas/setup-maven/releases/tag/v5

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
