### PR TITLE
Use zulu java distribution as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For default values you only need:
 | params            | destination  | default |
 |-------------------|--------------|---------|
 | java-version      | java-version | 17      |
-| java-distribution | distribution | temurin |
+| java-distribution | distribution | zulu    |
 
 ## cache
 

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
 
   java-distribution:
     description: 'Java distribution'
-    default: 'temurin'
+    default: 'zulu'
     required: false
 
   # cache


### PR DESCRIPTION
The temurin distribution doesn't support JDK 8 on new macOS runners

