### PR TITLE
chore: add checkout-ssh-key as input to allow git commits after the checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For default values you only need:
 | checkout-ref                 | ref                 |                          |
 | checkout-repository          | repository          | ${{ github.repository }} |
 | checkout-token               | token               | ${{ github.token }}      |
+| checkout-ssh-key             | ssh-key             |                          |
 | checkout-persist-credentials | persist-credentials | false                    |
 
 ## setup-java

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     required: false
     default: ${{ github.token }}
 
+  checkout-ssh-key:
+    description: 'SSH key used to fetch the repository. It allows to run authenticated git commands'
+    required: false
+
   # java jdk params
 
   java-version:
@@ -110,6 +114,7 @@ runs:
         ref: '${{ inputs.checkout-ref }}'
         repository: '${{ inputs.checkout-repository }}'
         token: '${{ inputs.checkout-token }}'
+        ssh-key: '${{ inputs.checkout-ssh-key }}'
 
     - uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
* Add checkout-ssh-key to allow checkout with ssh-key
* It allows workflows to commit using the ssh-key
* Note: user should add the private key to repository secrets