### PR TITLE
support adding settings-path for settings.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ So we can use for action:
 | settings-properties        | properties        |
 | settings-sonatypeSnapshots | sonatypeSnapshots |
 | settings-proxies           | proxies           |
-| settings-repositories      | repositories  
-| settings-path              | path
+| settings-repositories      | repositories      |
+| settings-path              | path              |
 
 # Testing against different Maven versions
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ So we can use for action:
 | settings-properties        | properties        |
 | settings-sonatypeSnapshots | sonatypeSnapshots |
 | settings-proxies           | proxies           |
-| settings-repositories      | repositories      |
+| settings-repositories      | repositories  
+| settings-path              | path
 
 # Testing against different Maven versions
 

--- a/action.yml
+++ b/action.yml
@@ -109,6 +109,9 @@ inputs:
   settings-repositories:
     description: 'repository settings definition in json array, e.g.: [ { "id": "repoId","name": "repoName","url": "url","snapshots": { "enabled": true } } ]'
     required: false
+  settings-path: 
+    description: 'override default path to settings.xml which is $HOME/.m2/settings.xml'
+    required: false  
 
 runs:
   using: 'composite'
@@ -160,3 +163,4 @@ runs:
         sonatypeSnapshots: '${{ inputs.settings-sonatypeSnapshots }}'
         proxies: '${{ inputs.settings-proxies }}'
         repositories: '${{ inputs.settings-repositories }}'
+        path: '${{ inputs.settings-path }}' 


### PR DESCRIPTION
As we know that the setup-maven-action uses the settings-maven-action https://github.com/marketplace/actions/maven-settings-action , I have checked the settings-action and inside the action.yaml file there is an attribute for path to override the settings.xml file, I would like to request a support for adding the path attribute.