### PR TITLE
Add parameter to maven server settings to prevent github server from being auto-created

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Setup Maven Action
+
 [![Test](https://github.com/s4u/setup-maven-action/actions/workflows/test.yml/badge.svg)](https://github.com/s4u/setup-maven-action/actions/workflows/test.yml)
 
 This is composite action which help to prepare GitHub Actions environment for Maven build by calling:
@@ -9,7 +10,8 @@ This is composite action which help to prepare GitHub Actions environment for Ma
 - [stCarolas/setup-maven](https://github.com/marketplace/actions/setup-maven)
 - [s4u/maven-settings-action](https://github.com/marketplace/actions/maven-settings-action)
 
-:exclamation: You **should not** include above actions in your configuration - in other case  those will be **called twice**. :exclamation:
+> [!IMPORTANT]
+> You **should not** include the above actions in your configuration.  If you do, they will be called twice.
 
 For default values you only need:
 
@@ -21,10 +23,10 @@ For default values you only need:
 
       - run: mvn -V ...
 ```
- 
-# Params mapping for sub actions
 
-## checkout
+## Params mapping for sub actions
+
+### checkout
 
 | params                       | destination         | default                  |
 |------------------------------|---------------------|--------------------------|
@@ -38,14 +40,14 @@ For default values you only need:
 | checkout-ssh-key             | ssh-key             |                          |
 | checkout-persist-credentials | persist-credentials | false                    |
 
-## setup-java
+### setup-java
 
 | params            | destination  | default |
 |-------------------|--------------|---------|
 | java-version      | java-version | 17      |
 | java-distribution | distribution | zulu    |
 
-## cache
+### cache
 
 A cache action is configured as:
 
@@ -64,18 +66,17 @@ So we can use for action:
 | params         | description                                              |
 |----------------|----------------------------------------------------------|
 | cache-enabled  | enable cache. Default true                               |
-| cache-path     | default cache path for Maven with value ~/.m2/repository | 
+| cache-path     | default cache path for Maven with value ~/.m2/repository |
 | cache-path-add | additional value for cache path                          |
 | cache-prefix   | prefix value for `key` and `restore-keys` cache params   |
 
-
-## setup-maven
+### setup-maven
 
 | params        | destination   | default |
 |---------------|---------------|---------|
 | maven-version | maven-version | 3.9.9   |
 
-## maven-settings-action
+### maven-settings-action
 
 | params                     | destination       |
 |----------------------------|-------------------|
@@ -85,8 +86,23 @@ So we can use for action:
 | settings-sonatypeSnapshots | sonatypeSnapshots |
 | settings-proxies           | proxies           |
 | settings-repositories      | repositories      |
+| settings-githubServer      | servers           |
 
-# Testing against different Maven versions
+#### `settings-githubServer` parameter
+
+This parameter is used to configure the GitHub server in the maven settings file.  By default, it'll add the following server configuration:
+
+```xml
+<server>
+  <id>github</id>
+  <username>${env.GITHUB_ACTOR}</username>
+  <password>${env.GITHUB_TOKEN}</password>
+</server>
+```
+
+If you are including a custom github server setting as part of the `settings-servers` parameter, you can set this parameter to `false` to prevent the default GitHub server configuration from being added to the maven settings file twice.
+
+## Testing against different Maven versions
 
 ```yaml
 
@@ -111,13 +127,13 @@ jobs:
       - run: mvn -V ...
 ```
 
-# Contributions
+## Contributions
 
 - Contributions are welcome!
 - Give :star: - if you want to encourage me to work on a project
 - Don't hesitate to create issues for new features you dream of or if you suspect some bug
 
-# Project versioning
+## Project versioning
 
 This project uses [Semantic Versioning](https://semver.org/).
 We recommended using the latest and specific release version.
@@ -125,6 +141,6 @@ We recommended using the latest and specific release version.
 In order to keep your project dependencies up to date you can watch this repository *(Releases only)*
 or use automatic tools like [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates).
 
-# License
+## License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -110,6 +110,11 @@ inputs:
     description: 'repository settings definition in json array, e.g.: [ { "id": "repoId","name": "repoName","url": "url","snapshots": { "enabled": true } } ]'
     required: false
 
+  settings-githubServer:
+    description: 'add github server to maven settings.  This gets added as `server-id: github; username=$GITHUB_ACTOR (environment variable); password=$GITHUB_TOKEN (environment variable)` where $GITHUB_ACTOR is the actor of the workflow and $GITHUB_TOKEN is the token of the workflow.  This is useful for github packages, as long as $GITHUB_TOKEN has the correct permissions. to access the packages repo.'
+    default: "true"
+    required: false
+
 runs:
   using: 'composite'
 
@@ -160,3 +165,4 @@ runs:
         sonatypeSnapshots: '${{ inputs.settings-sonatypeSnapshots }}'
         proxies: '${{ inputs.settings-proxies }}'
         repositories: '${{ inputs.settings-repositories }}'
+        githubServer: '${{ inputs.settings-githubServer }}'

--- a/pom.xml
+++ b/pom.xml
@@ -66,4 +66,3 @@
         </plugins>
     </build>
 </project>
- 

--- a/pom.xml
+++ b/pom.xml
@@ -66,3 +66,4 @@
         </plugins>
     </build>
 </project>
+ 


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `action.yml` files to improve documentation and add a new parameter for configuring the GitHub server in Maven settings. The most important changes include reformatting the README for clarity, adding detailed information about the `settings-githubServer` parameter, and updating the `action.yml` file to support this new parameter.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R29): Reformatted headers for better readability and consistency. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R50) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R79) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R144)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R14): Updated the warning about including certain actions to use a more standard formatting style.

New feature:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R89-R105): Added detailed information about the `settings-githubServer` parameter, including its purpose and default configuration.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R113-R117): Introduced the `settings-githubServer` parameter to allow adding GitHub server credentials to the Maven settings file. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R113-R117) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R168)