### PR TITLE
Add support to checkout Git-LFS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ For default values you only need:
 | checkout-token               | token               | ${{ github.token }}      |
 | checkout-ssh-key             | ssh-key             |                          |
 | checkout-persist-credentials | persist-credentials | false                    |
+| checkout-lfs                 | lfs                 | false                    |
 
 ## setup-java
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: 'SSH key used to fetch the repository. It allows to run authenticated git commands'
     required: false
 
+  checkout-lfs:
+    description: 'Whether to download Git-LFS files'
+    required: false
+
   # java jdk params
 
   java-version:
@@ -143,6 +147,7 @@ runs:
         repository: '${{ inputs.checkout-repository }}'
         token: '${{ inputs.checkout-token }}'
         ssh-key: '${{ inputs.checkout-ssh-key }}'
+        lfs: '${{ inputs.checkout-lfs }}'
 
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
       with:

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: 'SSH key used to fetch the repository. It allows to run authenticated git commands'
     required: false
 
+  checkout-lfs:
+    description: 'Whether to download Git-LFS files'
+    required: false
+
   # java jdk params
 
   java-version:
@@ -143,6 +147,7 @@ runs:
         repository: '${{ inputs.checkout-repository }}'
         token: '${{ inputs.checkout-token }}'
         ssh-key: '${{ inputs.checkout-ssh-key }}'
+        lfs: '${{ inputs.checkout-lfs }}'
 
     - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c
       with:


### PR DESCRIPTION
### Feature:
Enable download Git-LFS files by exposing the _lfs_ flag in the checkout plugin
